### PR TITLE
Remove reference to reserved extension block

### DIFF
--- a/draft-wood-privacypass-auth-scheme-extensions.md
+++ b/draft-wood-privacypass-auth-scheme-extensions.md
@@ -148,8 +148,5 @@ has a clear description about the privacy implications of using the extension
 framed in the context of partitioning the client anonymity set as described
 in {{Section 6.1 of ?ARCHITECTURE}}.
 
-Values 0xF000-0xFFFF are reserved for private use, to enable proprietary uses
-and limited experimentation.
-
 --- back
 


### PR DESCRIPTION
Echoing https://github.com/ietf-wg-privacypass/base-drafts/pull/469, which addresses https://github.com/ietf-wg-privacypass/base-drafts/issues/451 if we were to bring this into base-drafts.