### PR TITLE
Updates draft to comply with RFC9110, and better highlight scope

### DIFF
--- a/draft-wood-privacypass-auth-scheme-extensions.md
+++ b/draft-wood-privacypass-auth-scheme-extensions.md
@@ -124,15 +124,16 @@ metadata for the issuance protocol. Candidate issuance protocols are specified i
 # Extensions Negotiation {#negotiation}
 
 The mechanism by which Clients and Origins determine which set of extensions to provide
-for redemption is out of scope for this document. In some Privacy Pass deployments, the set
-of extensions may be well known Clients and Origins and therefore not require negotiation.
-In other settings, negotiation may be required. However, negotiation can raise privacy
-risks, especially if negotiation can be abused by Origins for partitioning Clients and
-risking Origin-Client unlinkability. Some of these risks may be mitigated if all Clients
-in a given redemption context respond to negotiation in the same manner. However, if
-Clients have different observable behavior, e.g., if certain extension use is determined
-by user choice, Origins can observe this differential behavior and therefore partition
-Clients in a redemption context.
+for redemption is out of scope for this document.
+
+In some Privacy Pass deployments, the set of extensions may be well known Clients and Origins
+and therefore not require negotiation. In other settings, negotiation may be required.
+However, negotiation can raise privacy risks, especially if negotiation can be abused by
+Origins for partitioning Clients and risking Origin-Client unlinkability. Some of these risks
+may be mitigated if all Clients in a given redemption context respond to negotiation in the
+same manner. However, if Clients have different observable behavior, e.g., if certain
+extension use is determined by user choice, Origins can observe this differential behavior
+and therefore partition Clients in a redemption context.
 
 # Security Considerations
 

--- a/draft-wood-privacypass-auth-scheme-extensions.md
+++ b/draft-wood-privacypass-auth-scheme-extensions.md
@@ -109,7 +109,7 @@ authentication header. As an example, Clients presenting this extension paramete
 would use an Authorization header field like the following:
 
 ~~~
-Authorization: PrivateToken token="abc..." extensions="def..."
+Authorization: PrivateToken token="abc...", extensions="def..."
 ~~~
 
 Future documents may specify extensions to be included in this structure.


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc9110#name-lists-rule-abnf-extension
PrivateToken parameters are `#auth-params`, which are comma separated.

In addition, this PR updates extension negotiation section to have the first sentence separate from the privacy risk/discussion