### PR TITLE
Add precision on extension types

### DIFF
--- a/draft-wood-privacypass-auth-scheme-extensions.md
+++ b/draft-wood-privacypass-auth-scheme-extensions.md
@@ -103,10 +103,10 @@ list is also a 2-octet integer, in network byte order.
 
 Clients, Issuers, and Origins all agree on the content and encoding of this Extensions
 structure, i.e., they agree on the same type-length-value list. The list MUST be ordered
-by ExtensionType value, from 1 to 65535. The value of the Extensions structure is used
-as-is when verifying the value of the corresponding "token" parameter in the "PrivateToken"
-authentication header. As an example, Clients presenting this extension parameter to origins
-would use an Authorization header field like the following:
+by ExtensionType value, from 0 to 65535. Extension types MAY be repeated. The value of the
+Extensions structure is used as-is when verifying the value of the corresponding "token" parameter
+in the "PrivateToken" authentication header. As an example, Clients presenting this extension
+parameter to origins would use an Authorization header field like the following:
 
 ~~~
 Authorization: PrivateToken token="abc...", extensions="def..."

--- a/draft-wood-privacypass-auth-scheme-extensions.md
+++ b/draft-wood-privacypass-auth-scheme-extensions.md
@@ -124,7 +124,7 @@ metadata for the issuance protocol. Candidate issuance protocols are specified i
 # Extensions Negotiation {#negotiation}
 
 The mechanism Clients and Origins use to determine which set of extensions to provide
-for redemption is out of scope for this document. 
+for redemption is out of scope for this document.
 
 In some Privacy Pass deployments, the set
 of extensions may be well known to Clients and Origins and thus do not require negotiation.


### PR DESCRIPTION
The draft is ambiguous on two points, which this commit addresses:
1. extension types MAY be repeated,
2. extension type MAY be `0`, even though this is a reseved value.
   Otherwise, we must update the structure to start at `1`.

In addition, this commit fixes lint which the CI complains about.